### PR TITLE
Change add_newmoon_code function and rename

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,7 @@
 
 export(FullPath)
 export(abundance)
-export(add_newmoon_code)
+export(add_time)
 export(add_seasons)
 export(download_observations)
 export(filter_plots)

--- a/R/RodentAbundances.R
+++ b/R/RodentAbundances.R
@@ -86,7 +86,7 @@ abundance <- function(path = '~', level="Site",type="Rodents",
   }
 
   ###########Switch to new moon number if time== 'newmoon'------------------
-  abundances = add_newmoon_code(abundances, newmoons, time)
+  abundances = add_time(abundances, newmoons, time)
 
   ##########Convert data to crosstab ----------------------
   if(shape %in% c("Crosstab","crosstab")){

--- a/R/data_processing.R
+++ b/R/data_processing.R
@@ -234,7 +234,7 @@ join_trapping_to_rodents = function(rodent_data, trapping_table, incomplete){
   return(rodent_table)
 }
 
-#' @title Add NewMoon Codes
+#' @title Add User-specified time column
 #'
 #' @description
 #' period codes denote the number of censuses that have occurred, but are
@@ -242,24 +242,37 @@ join_trapping_to_rodents = function(rodent_data, trapping_table, incomplete){
 #' censuses are missed (weather, transport issues,etc). You can't pick this
 #' up with the period code. Because censues may not always occur monthly due to
 #' the newmoon -  a new moon code was devised to give a standardized language
-#' of time for forcasting in particular.
+#' of time for forcasting in particular. This function allows the user to decide
+#' if they want to use the rodent period code, the new moon code, the date of 
+#' the rodent census, or have their data with all three time formats
 #'
 #' @param summary_table Data.table with summarized rodent data.
 #' @param newmoon_table Data_table linking newmoon codes with period codes.
-#' @param time Character. Denotes whether newmoon codes are desired.
+#' @param time Character. Denotes whether newmoon codes, period codes,
+#' and/or date are desired.
 #'
-#' @return Data.table of summarized rodent data with period or newmoon code
+#' @return Data.table of summarized rodent data with user-specified time format
 #'
 #' @export
 #'
-add_newmoon_code = function(summary_table, newmoon_table, time){
+
+add_time = function(summary_table, newmoon_table, time='period'){
+  newmoon_table$censusdate = as.Date(newmoon_table$censusdate)
+  join_summary_newmoon = dplyr::right_join(newmoon_table,summary_table,
+                                           by=c("period" = "period")) %>%
+    dplyr::filter(period <= max(period,na.rm=T))
   if(time %in% c("NewMoon","Newmoon","newmoon")){
-      summary_table = dplyr::right_join(newmoon_table,summary_table,
-                                by=c("period" = "period")) %>%
-        dplyr::filter(period <= max(period,na.rm=T)) %>%
-        dplyr::select(-newmoondate,-period,-censusdate)
-    }
-  return(summary_table)
+    join_summary_newmoon = dplyr::select(join_summary_newmoon, -newmoondate,
+                                         -period,-censusdate)
+  } else if (time %in% c("Date","date")) {
+    join_summary_newmoon = dplyr::select(join_summary_newmoon,-newmoondate,
+                                         -period,-newmoonnumber)
+  } else if (time %in% c("All","all")) {
+    join_summary_newmoon = dplyr::select(join_summary_newmoon,-newmoondate)
+  } else
+    join_summary_newmoon = summary_table
+  
+  return(join_summary_newmoon)
 }
 
 #' @title Make Crosstab


### PR DESCRIPTION
This modifies the add_newmoon_code function and generalizes it to allow the user to specify whether they want period code, newmoon code or date with the rodent data. It also allows the user to choose all three formats. It modifies the function and renames it add_time