### PR TITLE
Update handling to NDVI data to match new format

### DIFF
--- a/R/Weather.R
+++ b/R/Weather.R
@@ -10,14 +10,9 @@
 #' @export
 #'
 weather <- function(level, path = '~') {
-
-
   weather_new=read.csv(FullPath('PortalData/Weather/Portal_weather.csv', path), na.strings=c(""), stringsAsFactors = FALSE)
   weather_old=read.csv(FullPath('PortalData/Weather/Portal_weather_19801989.csv', path), na.strings=c("-99"), stringsAsFactors = FALSE)
   NDVI=read.csv(FullPath('PortalData/NDVI/monthly_NDVI.csv', path), na.strings=c("-99"), stringsAsFactors = FALSE)
-
-  # Data cleanup
-    NDVI$month=as.numeric(gsub( ".*-", "", NDVI$date )); NDVI$year=as.numeric(gsub( "-.*$", "", NDVI$date ))
 
   ###########Summarise by Day ----------------------
   days = weather_new %>%
@@ -34,8 +29,8 @@ if (level=='Monthly') {
     dplyr::group_by(year, month) %>%
     dplyr::summarize(mintemp=min(mintemp,na.rm=T),maxtemp=max(maxtemp,na.rm=T),meantemp=mean(meantemp,na.rm=T),precipitation=sum(precipitation,na.rm=T))
 
-  weather=dplyr::full_join(weather,NDVI) %>% dplyr::select(-date, -X) %>% dplyr::arrange(year,month)
-  weather$NDVI=as.numeric(weather$NDVI)
+  weather=dplyr::full_join(weather,NDVI) %>% dplyr::arrange(year,month)
+  weather$ndvi=as.numeric(weather$ndvi)
   }
 
 

--- a/tests/testthat/test-weather.R
+++ b/tests/testthat/test-weather.R
@@ -11,7 +11,7 @@ test_that("'Daily' option returns 7 columns" , {
 test_that("Monthly option returns 7 columns", {
   data = weather("Monthly",".")
   expect_that(dim(data)[2], equals(7))
-  expect_that(sum(colnames(data)==c("year","month","mintemp","maxtemp","meantemp","precipitation","NDVI")), equals(7))
+  expect_that(sum(colnames(data)==c("year","month","mintemp","maxtemp","meantemp","precipitation","ndvi")), equals(7))
 })
 
 


### PR DESCRIPTION
The format of the NDVI data was improved in the `PortalData` repository:

* https://github.com/weecology/PortalData/commit/1bc67c7b0be3b3bf4d1f23ea4003aa4cd18bb478
* https://github.com/weecology/PortalData/commit/30bead6c8f0602e987952becda0cb10810584b1e

This caused the `weather` function to error because the cleanup code for
handling the old format was no longer needed and as trying to access things that
didn't exist.

Fixes #73.