### PR TITLE
Test against previous and future R versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: r
 cache: packages
 sudo: false
 warnings_are_errors: false
+
+r:
+  - release
+  - devel


### PR DESCRIPTION
Testing against devel is recommend for R packages and passing against it is required for CRAN.