### PR TITLE
Suppress messages about columns used in joins

### DIFF
--- a/R/data_processing.R
+++ b/R/data_processing.R
@@ -13,7 +13,7 @@
 #' @noRd
 clean_data <- function(full_data, trapping_table) {
   names <- colnames(full_data)
-  full_data <- dplyr::left_join(full_data, trapping_table) %>%
+  full_data <- suppressMessages(dplyr::left_join(full_data, trapping_table)) %>%
     dplyr::filter(qcflag == 1) %>%
     dplyr::select(names) %>%
     unique()


### PR DESCRIPTION
The `clean_data` function by necessity doesn't explicitly declare the
columns it is using for joins (because this varies depending on the usage).
This results in "Joined by" messages being reported to the user that won't
make much sense to them in most cases. E.g., running abundance() returned
three separate "Joined by" messages.