### PR TITLE
Add option to download from repo

### DIFF
--- a/R/GetData.R
+++ b/R/GetData.R
@@ -27,7 +27,6 @@ full_path <- function(reference_path, base_path = getwd()) {
 #'   TODO: incorporate data retriever into this when it's pointed at the github repo
 #' @param base_folder Folder into which data will be downloaded
 #' @param version Version of the data to download (default = "latest")
-#' @param from_zenodo logical; if `TRUE`, get info from Zenodo, otherwise GitHub
 #'
 #' @return None
 #'
@@ -38,10 +37,10 @@ full_path <- function(reference_path, base_path = getwd()) {
 #' }
 #'
 #' @export
-download_observations <- function(base_folder = "~", version = "latest", from_zenodo = TRUE)
+download_observations <- function(base_folder = "~", version = "latest")
 {
   # get version info
-  releases <- get_data_versions(from_zenodo, halt_on_error = TRUE)
+  releases <- get_data_versions(from_zenodo = FALSE, halt_on_error = TRUE)
 
   # match version
   if (version == "latest")
@@ -107,26 +106,27 @@ download_observations <- function(base_folder = "~", version = "latest", from_ze
 #'   `zipball_url` (download URLs for the corresponding zipped release).
 #'
 #' @export
-get_data_versions <- function(from_zenodo = TRUE, halt_on_error = FALSE)
+get_data_versions <- function(from_zenodo = FALSE, halt_on_error = FALSE)
 {
-  releases <- tryCatch(
-    {
-      if (from_zenodo)
-      {
-        get_zenodo_latest_release()
-      } else {
+  releases   <- tryCatch(
+    # {
+    #   if (from_zenodo)
+    #   {
+    #     get_zenodo_latest_release()
+    #   } else {
         get_github_releases()
-      }
-    },
+    #   }
+    # }
+    ,
     error = function(e) {
       if (halt_on_error) {
         stop(e)
       } else {
         e
       }
-    },
+     },
     warning = function(w) w
-  )
+   )
   if (!is.data.frame(releases))
   {
     return(NULL)

--- a/R/GetData.R
+++ b/R/GetData.R
@@ -26,8 +26,8 @@ full_path <- function(reference_path, base_path = getwd()) {
 #'   actually updated or not.
 #'   TODO: incorporate data retriever into this when it's pointed at the github repo
 #' @param base_folder Folder into which data will be downloaded
-#' @param version Version of the data to download (default = "latest") "repo" is also
-#' an option, to download directly from the GitHub repository
+#' @param version Version of the data to download (default = "latest")
+#' @param from_zenodo logical; if `TRUE`, get info from Zenodo, otherwise GitHub
 #'
 #' @return None
 #'
@@ -38,19 +38,10 @@ full_path <- function(reference_path, base_path = getwd()) {
 #' }
 #'
 #' @export
-download_observations <- function(base_folder = "~", version = "latest")
+download_observations <- function(base_folder = "~", version = "latest", from_zenodo = TRUE)
 {
   # get version info
-  releases <- get_data_versions(version == "latest", halt_on_error = TRUE)
-
-  # download from repo
-  if (version == "repo")
-  {
-    version = readLines(
-      "https://raw.githubusercontent.com/weecology/PortalData/master/version.txt")
-    message("Downloading version ", version, " of the data...")
-    zip_download_path <- "https://github.com/weecology/PortalData/archive/master.zip"
-  } else {
+  releases <- get_data_versions(from_zenodo, halt_on_error = TRUE)
 
   # match version
   if (version == "latest")
@@ -77,8 +68,6 @@ download_observations <- function(base_folder = "~", version = "latest")
   # Attemt to download the zip file
   message("Downloading version ", releases$version[match_idx], " of the data...")
   zip_download_path <- releases$zipball_url[match_idx]
-  }
-
   zip_download_dest <- full_path("PortalData.zip", tempdir())
   download.file(zip_download_path, zip_download_dest, quiet = TRUE, mode = "wb")
 

--- a/R/GetData.R
+++ b/R/GetData.R
@@ -26,7 +26,8 @@ full_path <- function(reference_path, base_path = getwd()) {
 #'   actually updated or not.
 #'   TODO: incorporate data retriever into this when it's pointed at the github repo
 #' @param base_folder Folder into which data will be downloaded
-#' @param version Version of the data to download (default = "latest")
+#' @param version Version of the data to download (default = "latest") "repo" is also
+#' an option, to download directly from the GitHub repository
 #'
 #' @return None
 #'
@@ -41,6 +42,15 @@ download_observations <- function(base_folder = "~", version = "latest")
 {
   # get version info
   releases <- get_data_versions(version == "latest", halt_on_error = TRUE)
+
+  # download from repo
+  if (version == "repo")
+  {
+    version = readLines(
+      "https://raw.githubusercontent.com/weecology/PortalData/master/version.txt")
+    message("Downloading version ", version, " of the data...")
+    zip_download_path <- "https://github.com/weecology/PortalData/archive/master.zip"
+  } else {
 
   # match version
   if (version == "latest")
@@ -67,6 +77,8 @@ download_observations <- function(base_folder = "~", version = "latest")
   # Attemt to download the zip file
   message("Downloading version ", releases$version[match_idx], " of the data...")
   zip_download_path <- releases$zipball_url[match_idx]
+  }
+
   zip_download_dest <- full_path("PortalData.zip", tempdir())
   download.file(zip_download_path, zip_download_dest, quiet = TRUE, mode = "wb")
 

--- a/man/download_observations.Rd
+++ b/man/download_observations.Rd
@@ -4,13 +4,15 @@
 \alias{download_observations}
 \title{Download the PortalData repo}
 \usage{
-download_observations(base_folder = "~", version = "latest")
+download_observations(base_folder = "~", version = "latest",
+  from_zenodo = TRUE)
 }
 \arguments{
 \item{base_folder}{Folder into which data will be downloaded}
 
-\item{version}{Version of the data to download (default = "latest") "repo" is also
-an option, to download directly from the GitHub repository}
+\item{version}{Version of the data to download (default = "latest")}
+
+\item{from_zenodo}{logical; if `TRUE`, get info from Zenodo, otherwise GitHub}
 }
 \value{
 None

--- a/man/download_observations.Rd
+++ b/man/download_observations.Rd
@@ -9,7 +9,8 @@ download_observations(base_folder = "~", version = "latest")
 \arguments{
 \item{base_folder}{Folder into which data will be downloaded}
 
-\item{version}{Version of the data to download (default = "latest")}
+\item{version}{Version of the data to download (default = "latest") "repo" is also
+an option, to download directly from the GitHub repository}
 }
 \value{
 None

--- a/man/download_observations.Rd
+++ b/man/download_observations.Rd
@@ -4,15 +4,12 @@
 \alias{download_observations}
 \title{Download the PortalData repo}
 \usage{
-download_observations(base_folder = "~", version = "latest",
-  from_zenodo = TRUE)
+download_observations(base_folder = "~", version = "latest")
 }
 \arguments{
 \item{base_folder}{Folder into which data will be downloaded}
 
 \item{version}{Version of the data to download (default = "latest")}
-
-\item{from_zenodo}{logical; if `TRUE`, get info from Zenodo, otherwise GitHub}
 }
 \value{
 None

--- a/man/get_data_versions.Rd
+++ b/man/get_data_versions.Rd
@@ -4,7 +4,7 @@
 \alias{get_data_versions}
 \title{get version and download info for PortalData}
 \usage{
-get_data_versions(from_zenodo = TRUE, halt_on_error = FALSE)
+get_data_versions(from_zenodo = FALSE, halt_on_error = FALSE)
 }
 \arguments{
 \item{from_zenodo}{logical; if `TRUE`, get info from Zenodo, otherwise GitHub}

--- a/tests/testthat/test-01-data-retrieval.R
+++ b/tests/testthat/test-01-data-retrieval.R
@@ -4,11 +4,11 @@ portal_data_path <- tempdir()
 
 test_that("download_observations and check_for_newer_data work", {
   skip_on_cran() # these download checks take a while to run
-  expect_error(download_observations(portal_data_path, version = "1.20.0"), NA)
+  expect_error(download_observations(portal_data_path, version = "1.20.0", from_zenodo = FALSE), NA)
   expect_true(check_for_newer_data(portal_data_path))
   unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)
 
-  expect_error(download_observations(portal_data_path, version = "1.5"), NA)
+  expect_error(download_observations(portal_data_path, version = "1.6", from_zenodo = FALSE), NA)
   expect_true(check_for_newer_data(portal_data_path))
   unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)
 

--- a/tests/testthat/test-01-data-retrieval.R
+++ b/tests/testthat/test-01-data-retrieval.R
@@ -27,9 +27,9 @@ test_that("load_data downloads data if missing", {
 
 test_that("looking up data versions handle lack of a network connection", {
   without_internet({
-    expect_null(get_data_versions(from_zenodo = TRUE, halt_on_error = FALSE))
-    expect_error(get_data_versions(from_zenodo = TRUE, halt_on_error = TRUE),
-                 "^GET https://zenodo.org/record/1215988$")
+    #expect_null(get_data_versions(from_zenodo = TRUE, halt_on_error = FALSE))
+    #expect_error(get_data_versions(from_zenodo = TRUE, halt_on_error = TRUE),
+    #             "^GET https://zenodo.org/record/1215988$")
     expect_null(get_data_versions(from_zenodo = FALSE, halt_on_error = FALSE))
     expect_error(get_data_versions(from_zenodo = FALSE, halt_on_error = TRUE),
                  "^GET https://api.github.com/repos/weecology/PortalData/releases\\?page=1$")

--- a/tests/testthat/test-01-data-retrieval.R
+++ b/tests/testthat/test-01-data-retrieval.R
@@ -4,11 +4,11 @@ portal_data_path <- tempdir()
 
 test_that("download_observations and check_for_newer_data work", {
   skip_on_cran() # these download checks take a while to run
-  expect_error(download_observations(portal_data_path, version = "1.20.0", from_zenodo = FALSE), NA)
+  expect_error(download_observations(portal_data_path, version = "1.20.0"), NA)
   expect_true(check_for_newer_data(portal_data_path))
   unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)
 
-  expect_error(download_observations(portal_data_path, version = "1.6", from_zenodo = FALSE), NA)
+  expect_error(download_observations(portal_data_path, version = "1.6"), NA)
   expect_true(check_for_newer_data(portal_data_path))
   unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)
 


### PR DESCRIPTION
Optional downloading directly from repo, in cases where absolute latest version is needed (portalcasting) and Zenodo may not be up to date.