### PR TITLE
Fix calculation of abundance per species

### DIFF
--- a/vignettes/rodent-abundance-demo.Rmd
+++ b/vignettes/rodent-abundance-demo.Rmd
@@ -66,8 +66,8 @@ The first table that we loaded (`data_tables$rodent_data`) is a record of whatev
 rodent_abundance_by_plot <- abundance(path = portal_data_path, time = "date", level = "plot") 
 
 rodent_abundance <- rodent_abundance_by_plot %>%
-  gather(species, abundance, -censusdate, -plot) %>%
-  count(species, censusdate) %>%
+  gather(species, abundance, -censusdate, -treatment, -plot) %>%
+  count(species, censusdate, wt = abundance) %>%
   rename(abundance = n)
 print(summary(rodent_abundance))
 ```


### PR DESCRIPTION
I think the current code in the vignette is not working as intended (see Fig https://weecology.github.io/portalr/articles/rodent-abundance-demo.html#figure-abundance-over-time). I tried to fix with a couple of minor changes.

An alternative would be to call `rodent_abundance_by_plot <- abundance(path = portal_data_path, time = "date", level = "plot", shape = "flat") ` so there would be no need to call `gather`, just `count` to summarise abundance per species