### PR TITLE
Check GitHub minimally

### DIFF
--- a/R/download_data.R
+++ b/R/download_data.R
@@ -27,6 +27,7 @@ full_path <- function(reference_path, base_path = getwd()) {
 #'   TODO: incorporate data retriever into this when it's pointed at the github repo
 #' @param base_folder Folder into which data will be downloaded
 #' @param version Version of the data to download (default = "latest")
+#' @inheritParams get_data_versions
 #'
 #' @return None
 #'
@@ -37,10 +38,14 @@ full_path <- function(reference_path, base_path = getwd()) {
 #' }
 #'
 #' @export
-download_observations <- function(base_folder = "~", version = "latest")
+download_observations <- function(base_folder = "~", version = "latest", from_zenodo = FALSE)
 {
+  # only use zenodo if version == "latest"
+  if (version != "latest")
+    from_zenodo <- FALSE
+
   # get version info
-  releases <- get_data_versions(from_zenodo = FALSE, halt_on_error = TRUE)
+  releases <- get_data_versions(from_zenodo = from_zenodo, halt_on_error = TRUE)
 
   # match version
   if (version == "latest")
@@ -109,14 +114,14 @@ download_observations <- function(base_folder = "~", version = "latest")
 get_data_versions <- function(from_zenodo = FALSE, halt_on_error = FALSE)
 {
   releases   <- tryCatch(
-    # {
-    #   if (from_zenodo)
-    #   {
-    #     get_zenodo_latest_release()
-    #   } else {
+    {
+      if (from_zenodo)
+      {
+        get_zenodo_latest_release()
+      } else {
         get_github_releases()
-    #   }
-    # }
+      }
+    }
     ,
     error = function(e) {
       if (halt_on_error) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 .onAttach <- function(libname, pkgname) {
-  if (check_for_newer_data(base_folder = "~"))
+  if (interactive() && check_for_newer_data(base_folder = "~"))
   {
     packageStartupMessage("The data in the default path `", normalizePath("~"), "` is either missing or out of date.\n",
                           "Consider updating it using `download_observations()`.")

--- a/man/download_observations.Rd
+++ b/man/download_observations.Rd
@@ -4,12 +4,15 @@
 \alias{download_observations}
 \title{Download the PortalData repo}
 \usage{
-download_observations(base_folder = "~", version = "latest")
+download_observations(base_folder = "~", version = "latest",
+  from_zenodo = FALSE)
 }
 \arguments{
 \item{base_folder}{Folder into which data will be downloaded}
 
 \item{version}{Version of the data to download (default = "latest")}
+
+\item{from_zenodo}{logical; if `TRUE`, get info from Zenodo, otherwise GitHub}
 }
 \value{
 None

--- a/tests/testthat/test-01-data-retrieval.R
+++ b/tests/testthat/test-01-data-retrieval.R
@@ -15,6 +15,10 @@ test_that("download_observations and check_for_newer_data work", {
   expect_error(download_observations(portal_data_path, version = "1.5.9"))
   unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)
 
+  expect_error(download_observations(portal_data_path, from_zenodo = TRUE), NA)
+  expect_false(check_for_newer_data(portal_data_path))
+  unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)
+
   expect_error(download_observations(portal_data_path), NA)
   expect_false(check_for_newer_data(portal_data_path))
   unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)


### PR DESCRIPTION
* The check for newer data when loading portalr will only run if R detects it's running interactively.
* Re-enabled downloading of the latest version from Zenodo (use `download_observations(from_zenodo = TRUE)`)
* add a test

Should close #188 and get around the issue in PortalPredictions if `download_observations()` is modified accordingly. (cc @juniperlsimonis )