### PR TITLE
restricting the R code in vignettes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^Meta$
+^doc$
 ^codecov\.yml$
 ^LICENSE\.md$
 ^CONTRIBUTING\.md$
@@ -8,3 +10,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^paper$
+^.Renviron$

--- a/.Renviron
+++ b/.Renviron
@@ -1,0 +1,1 @@
+portalr_vignette_build=TRUE

--- a/.Renviron
+++ b/.Renviron
@@ -1,1 +1,1 @@
-portalr_vignette_build=TRUE
+portalr_vignette_build=1234

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+Meta
+doc
 # Ignore testing data folder
 /tests/testthat/PortalData
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: portalr
 Title: Create Useful Summaries of the Portal Data
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(person(c("Glenda", "M."), "Yenni", role = c("aut", "cre"), 
                     email = "glenda@weecology.org", 
                     comment = c(ORCID = "0000-0001-6969-1848")), 

--- a/vignettes/portal_researcher_examples.Rmd
+++ b/vignettes/portal_researcher_examples.Rmd
@@ -11,7 +11,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = Sys.getenv("portalr_vignette_build")
 )
 ```
 

--- a/vignettes/portal_researcher_examples.Rmd
+++ b/vignettes/portal_researcher_examples.Rmd
@@ -12,7 +12,7 @@ vignette: >
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = Sys.getenv("portalr_vignette_build")
+  eval = nzchar(Sys.getenv("portalr_vignette_build"))
 )
 ```
 

--- a/vignettes/rodent-abundance-demo.Rmd
+++ b/vignettes/rodent-abundance-demo.Rmd
@@ -11,9 +11,11 @@ vignette: >
 ---
 
 ```{r setup, include = FALSE}
+date_span <- list(iso_date = 0)
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = Sys.getenv("portalr_vignette_build")
 )
 ```
 

--- a/vignettes/rodent-abundance-demo.Rmd
+++ b/vignettes/rodent-abundance-demo.Rmd
@@ -15,7 +15,7 @@ date_span <- list(iso_date = 0)
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = Sys.getenv("portalr_vignette_build")
+  eval = nzchar(Sys.getenv("portalr_vignette_build")) 
 )
 ```
 


### PR DESCRIPTION
now including an environmental variable portalr_vignette_build (set to "1234") that defines if the R code chunks are run or not in the vignettes (if the variable is present, the chunks are run; if the variable is absent the chunks are not run). the default set up by the project-level .Renviron file is "1234", but the .Renviron file is not included in the R build (i.e. it's listed in the .Rbuildignore) so the vignettes should be build without the code chunks running during the Rbuild on CRAN (which only tests to see if the vignettes can be built, but does not save the output), but an individual can build a local copy of the vignettes by using `devtools::build_vignettes()` 