### PR TITLE
Remove version number from README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# portalr `r packageVersion("portalr")`
+# portalr
 
 [![Build Status](https://travis-ci.org/weecology/portalr.svg?branch=master)](https://travis-ci.org/weecology/portalr)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/weecology/portalr/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# portalr 0.2.6
+# portalr
 
 [![Build
 Status](https://travis-ci.org/weecology/portalr.svg?branch=master)](https://travis-ci.org/weecology/portalr)


### PR DESCRIPTION
Version numbers aren't traditionally included in README's, in part
because updating them can be missed and cause confusion.
This has now happened a couple of times for portalr, see #207 #218
so this PR suggests removing it to keep the version in one
place (DESCRIPTION).