### PR TITLE
Remove donttest examples, closes #268

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,5 +79,4 @@ Suggests:
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
-LazyData: true
 RoxygenNote: 7.1.1

--- a/R/download_data.R
+++ b/R/download_data.R
@@ -28,11 +28,6 @@ full_path <- function(reference_path, base_path = getwd()) {
 #'
 #' @return None
 #'
-#' @examples
-#' \donttest{
-#'   download_observations()
-#'   download_observations("~/old-data", version = "1.50.0")
-#' }
 #'
 #' @export
 download_observations <- function(path = get_default_data_path(),

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -28,10 +28,6 @@
 #'     \code{plots_table} \tab rodent treatment assignments for each plot\cr
 #'   }
 #'
-#' @examples
-#' \donttest{
-#' portal_data <- load_rodent_data("repo")
-#' }
 #' @export
 #'
 load_rodent_data <- function(path = get_default_data_path(),
@@ -89,10 +85,6 @@ load_rodent_data <- function(path = get_default_data_path(),
 #'
 #' @export
 #'
-#' @examples
-#' \donttest{
-#' portal_plant_data <- load_plant_data("repo")
-#' }
 
 load_plant_data <- function(path = get_default_data_path(),
                             download_if_missing = TRUE, quiet = FALSE)
@@ -134,10 +126,6 @@ load_plant_data <- function(path = get_default_data_path(),
 #'
 #' @export
 #'
-#' @examples
-#' \donttest{
-#' portal_ant_data <- load_ant_data("repo")
-#' }
 
 load_ant_data <- function(path = get_default_data_path(),
                           download_if_missing = TRUE, quiet = FALSE)
@@ -168,10 +156,6 @@ load_ant_data <- function(path = get_default_data_path(),
 #'     \code{newmoons_table} \tab pairs census periods with newmoons\cr
 #'   }
 #'
-#' @examples
-#' \donttest{
-#' trapping_data <- load_trapping_data("repo")
-#' }
 #' @export
 load_trapping_data <- function(path = get_default_data_path(),
                                download_if_missing = TRUE, clean = TRUE,
@@ -205,10 +189,6 @@ load_trapping_data <- function(path = get_default_data_path(),
 #' @inheritParams load_rodent_data
 #' @inheritParams utils::read.table
 #'
-#' @examples
-#' \donttest{
-#' rodent_species <- load_datafile("Rodents/Portal_rodent_species.csv")
-#' }
 #' @export
 load_datafile <- function(datafile, na.strings = "", path = get_default_data_path(),
                           download_if_missing = TRUE, quiet = TRUE)

--- a/R/season_function.R
+++ b/R/season_function.R
@@ -127,11 +127,6 @@ add_seasons <- function(data, level = "site", season_level = 2,
 #'
 #' @param ... arguments passed to \code{\link{add_seasons}}
 #'
-#' @examples
-#' \donttest{
-#' yearly(abundance(path = "repo", time = "newmoon"),
-#'        date_column = "newmoonnumber", path = "repo")
-#' }
 #' @export
 #'
 yearly <- function(...) {

--- a/R/summarize_plants.R
+++ b/R/summarize_plants.R
@@ -90,10 +90,6 @@ summarize_plant_data <- function(path = get_default_data_path(),
 #'
 #' @param ... arguments passed to \code{\link{summarize_plant_data}}
 #'
-#' @examples
-#' \donttest{
-#' plant_abundance("repo")
-#' }
 #' @export
 #'
 plant_abundance <- function(..., shape = "flat") {

--- a/R/summarize_rodents.R
+++ b/R/summarize_rodents.R
@@ -109,10 +109,6 @@ summarize_rodent_data <- function(path = get_default_data_path(),
 #'
 #' @param ... arguments passed to \code{\link{summarize_rodent_data}}
 #'
-#' @examples
-#' \donttest{
-#' abundance("repo")
-#' }
 #' @export
 #'
 abundance <- function(...) {
@@ -125,10 +121,6 @@ abundance <- function(...) {
 #'
 #' @inheritParams abundance
 #'
-#' @examples
-#' \donttest{
-#' biomass("repo")
-#' }
 #' @export
 #'
 biomass <- function(...) {
@@ -143,10 +135,6 @@ biomass <- function(...) {
 #'
 #' @inheritParams abundance
 #'
-#' @examples
-#' \donttest{
-#' energy("repo")
-#' }
 #' @export
 #'
 energy <- function(...) {
@@ -160,10 +148,6 @@ energy <- function(...) {
 #'
 #'@inheritParams abundance
 #'
-#' @examples
-#' \donttest{
-#' rates("repo")
-#' }
 #' @export
 #'
 rates <- function(...) {

--- a/man/add_seasons.Rd
+++ b/man/add_seasons.Rd
@@ -59,9 +59,3 @@ Also applies specified functions to the specified summary level.
 
 \code{yearly} generates a table of yearly means
 }
-\examples{
-\donttest{
-yearly(abundance(path = "repo", time = "newmoon"),
-       date_column = "newmoonnumber", path = "repo")
-}
-}

--- a/man/download_observations.Rd
+++ b/man/download_observations.Rd
@@ -28,10 +28,3 @@ This downloads the latest portal data regardless if they are
   actually updated or not.
   TODO: incorporate data retriever into this when it's pointed at the github repo
 }
-\examples{
-\donttest{
-  download_observations()
-  download_observations("~/old-data", version = "1.50.0")
-}
-
-}

--- a/man/load_datafile.Rd
+++ b/man/load_datafile.Rd
@@ -35,8 +35,3 @@ does checking for whether a particular datafile exists and then
   reads it in, using na_strings to determine what gets converted to NA. It
   can also download the dataset if it's missing locally.
 }
-\examples{
-\donttest{
-rodent_species <- load_datafile("Rodents/Portal_rodent_species.csv")
-}
-}

--- a/man/load_rodent_data.Rd
+++ b/man/load_rodent_data.Rd
@@ -93,17 +93,3 @@ Loads Portal data files from either a user-defined
 
 \code{\link{load_trapping_data}} loads just the rodent trapping files
 }
-\examples{
-\donttest{
-portal_data <- load_rodent_data("repo")
-}
-\donttest{
-portal_plant_data <- load_plant_data("repo")
-}
-\donttest{
-portal_ant_data <- load_ant_data("repo")
-}
-\donttest{
-trapping_data <- load_trapping_data("repo")
-}
-}

--- a/man/summarize_plant_data.Rd
+++ b/man/summarize_plant_data.Rd
@@ -114,8 +114,3 @@ This function is a generic interface into creating
 
 \code{plant_abundance} generates a table of plant abundance
 }
-\examples{
-\donttest{
-plant_abundance("repo")
-}
-}

--- a/man/summarize_rodent_data.Rd
+++ b/man/summarize_rodent_data.Rd
@@ -142,17 +142,3 @@ This function is a generic interface into creating summaries
 * \code{rates()} generates a table of rodent growth rates
   (computed as r=log(N[t+1]/N[t])
 }
-\examples{
-\donttest{
-abundance("repo")
-}
-\donttest{
-biomass("repo")
-}
-\donttest{
-energy("repo")
-}
-\donttest{
-rates("repo")
-}
-}


### PR DESCRIPTION
R 4.0.0 has changed R CMD check --as-cran now runs \donttest examples (which are run by example()) instead of instructing the tester to do so. 