### PR TITLE
adding an overwrite arg to download_observations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: portalr
 Title: Create Useful Summaries of the Portal Data
-Version: 0.3.11
+Version: 0.3.12
 Authors@R: 
     c(person(given = c("Glenda", "M."),
              family = "Yenni",
@@ -78,4 +78,4 @@ Suggests:
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3

--- a/man/download_observations.Rd
+++ b/man/download_observations.Rd
@@ -11,7 +11,8 @@ download_observations(
   quiet = FALSE,
   verbose = FALSE,
   pause = 30,
-  timeout = getOption("timeout")
+  timeout = getOption("timeout"),
+  overwrite = FALSE
 )
 }
 \arguments{
@@ -20,7 +21,7 @@ download_observations(
 \item{version}{Version of the data to download (default = "latest").
 If \code{NULL}, returns.}
 
-\item{from_zenodo}{logical; if `TRUE`, get info from Zenodo, otherwise GitHub}
+\item{from_zenodo}{\code{logical}; if `TRUE`, get info from Zenodo, otherwise GitHub}
 
 \item{quiet}{logical, whether to download data silently.}
 
@@ -29,6 +30,8 @@ If \code{NULL}, returns.}
 \item{pause}{Positive \code{integer} or integer \code{numeric} seconds for pausing during steps around unzipping that require time delayment.}
 
 \item{timeout}{Positive \code{integer} or integer \code{numeric} seconds for timeout on downloads. Temporarily overrides the \code{"timeout"} option in \code{\link[base]{options}}.}
+
+\item{overwrite}{\code{logical} indicator of whether or not existing files or folders (such as the archive) should be over-written if an up-to-date copy exists (most users should leave as \code{FALSE}).}
 }
 \value{
 NULL invisibly.

--- a/tests/testthat/test-01-data-retrieval.R
+++ b/tests/testthat/test-01-data-retrieval.R
@@ -11,6 +11,12 @@ test_that("download_observations and check_for_newer_data work", {
     })
     unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)
 
+    expect_message(download_observations(portal_data_path))
+    expect_message(download_observations(portal_data_path))
+    unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)
+
+
+
     expect_error(download_observations(portal_data_path, version = "1.6.0"), NA)
     expect_true(check_for_newer_data(portal_data_path))
     unlink(file.path(portal_data_path, "PortalData"), recursive = TRUE)


### PR DESCRIPTION
prevent re-downloading the observations if the version is the same